### PR TITLE
Update Statefun to 3.3.0

### DIFF
--- a/embedded-example/build.gradle
+++ b/embedded-example/build.gradle
@@ -1,14 +1,7 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version "$kotlinVersion" apply false
-    id "org.jetbrains.kotlin.kapt" version "$kotlinVersion" apply false
+    id 'java'
 }
 
 allprojects {
     group 'embedded-example'
-}
-
-subprojects {
-    repositories {
-        mavenCentral()
-    }
 }

--- a/embedded-example/protocols/build.gradle
+++ b/embedded-example/protocols/build.gradle
@@ -1,18 +1,17 @@
 plugins {
+    id 'idea'
     id 'java-library'
-    id 'com.google.protobuf' version "0.8.14"
+    id 'com.google.protobuf'
 }
 
-apply plugin: 'idea'
-
 dependencies {
-    compileOnly "com.google.protobuf:protobuf-java:$protobufVersion"
+    api libs.protobuf.java
 }
 
 protobuf {
     protoc {
         // The artifact spec for the Protobuf Compiler
-        artifact = "com.google.protobuf:protoc:$protobufVersion"
+        artifact = libs.protobuf.compiler.get().toString()
     }
 
     generatedFilesBaseDir = "$projectDir/src/generated"

--- a/embedded-example/settings.gradle
+++ b/embedded-example/settings.gradle
@@ -1,2 +1,46 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version '1.8.21'
+        id 'org.jetbrains.kotlin.kapt' version '1.8.21'
+        id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.21'
+        id 'com.google.protobuf' version '0.9.3'
+        id 'com.google.cloud.tools.jib' version '3.3.1'
+    }
+    repositories {
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            version('flink', '1.16.2')
+            version('protobuf', '3.21.9')
+            version('statefun', '3.3.0')
+            version('serialization', '1.3.2')
+
+            library('asciitable', 'de.vandermeer', 'asciitable').version('0.3.2')
+            library('auto-service', 'com.google.auto.service', 'auto-service').version('1.0-rc6')
+            library('auto-service-annotations', 'com.google.auto.service', 'auto-service-annotations').version('1.0-rc6')
+            library('protobuf-compiler', 'com.google.protobuf', 'protoc').versionRef('protobuf')
+            library('protobuf-java', 'com.google.protobuf', 'protobuf-java').versionRef('protobuf')
+            library('protobuf-util', 'com.google.protobuf', 'protobuf-java-util').versionRef('protobuf')
+            library('serialization-core', 'org.jetbrains.kotlinx', 'kotlinx-serialization-core').versionRef('serialization')
+            library('serialization-json', 'org.jetbrains.kotlinx', 'kotlinx-serialization-json').versionRef('serialization')
+            library('statefun-distribution', 'org.apache.flink', 'statefun-flink-distribution').versionRef('statefun')
+            library('statefun-sdk', 'org.apache.flink', 'statefun-sdk-java').versionRef('statefun')
+            library('statefun-harness', 'org.apache.flink', 'statefun-flink-harness').versionRef('statefun')
+            library('slf4j-api', 'org.slf4j', 'slf4j-api').version('1.7.36')
+            library('slf4j-impl', 'org.apache.logging.log4j', 'log4j-slf4j-impl').version('2.17.2')
+
+            bundle('serialization', ['serialization-core', 'serialization-json'])
+            bundle('protobuf', ['protobuf-java', 'protobuf-util'])
+        }
+    }
+    repositories {
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'example'
 include 'protocols', 'shopping'

--- a/embedded-example/shopping/build.gradle
+++ b/embedded-example/shopping/build.gradle
@@ -1,16 +1,24 @@
 plugins {
     id 'application'
-    id "com.google.cloud.tools.jib" version "$jibVersion"
-    id "org.jetbrains.kotlin.plugin.serialization" version "$kotlinVersion"
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.kotlin.kapt'
+    id 'com.google.cloud.tools.jib'
+    id 'org.jetbrains.kotlin.plugin.serialization'
 }
-
-apply plugin: 'idea'
-apply plugin: 'kotlin'
-apply plugin: "kotlin-kapt"
 
 archivesBaseName = 'statefun-shopping'
 mainClassName = 'shopping.Harness'
 //mainClassName = 'org.apache.flink.statefun.flink.core.StatefulFunctionsJob'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+kapt {
+    correctErrorTypes = true
+}
 
 configurations {
     provided
@@ -23,25 +31,22 @@ configurations {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion"
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib'
+    implementation libs.bundles.serialization
 
     implementation project(':protocols')
-    implementation "de.vandermeer:asciitable:0.3.2"
+    implementation libs.asciitable
 
-    provided "com.google.protobuf:protobuf-java:$protobufVersion"
-    provided "com.google.protobuf:protobuf-java-util:$protobufVersion"
-    provided "org.apache.flink:statefun-sdk-java:$statefunVersion"
-    provided "org.apache.flink:statefun-flink-harness:$statefunVersion"
+    provided libs.bundles.protobuf
+    provided libs.statefun.sdk
+    provided libs.statefun.harness
+    provided libs.slf4j.api
+    provided libs.slf4j.impl
 
-    provided 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'
-    provided 'org.slf4j:slf4j-api:1.7.36'
+    kapt libs.auto.service
+    compileOnly libs.auto.service.annotations
 
-    compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"
-    kapt "com.google.auto.service:auto-service:1.0-rc6"
-
-    statefunLib "org.apache.flink:statefun-flink-distribution:$statefunVersion"
+    statefunLib libs.statefun.distribution
 }
 
 sourceSets {
@@ -53,12 +58,6 @@ sourceSets {
         compileClasspath += configurations.provided
         runtimeClasspath += main.output
         runtimeClasspath += configurations.provided
-    }
-}
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 

--- a/remote-example/Dockerfile
+++ b/remote-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.11-slim-buster
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/remote-example/Dockerfile.flink
+++ b/remote-example/Dockerfile.flink
@@ -1,4 +1,4 @@
-FROM apache/flink-statefun:3.2.0-java11
+FROM apache/flink-statefun:3.3.0-java11
 
 RUN mkdir -p /opt/statefun/modules/shopping
 ADD module.yaml /opt/statefun/modules/shopping

--- a/remote-example/README.md
+++ b/remote-example/README.md
@@ -1,6 +1,6 @@
 # Remote statefun example
 
-Similar to the classic [shopping-cart](https://github.com/apache/flink-statefun-playground/tree/release-3.2) example, this example demonstrates two "statefun" functions:
+Similar to the classic [shopping-cart](https://github.com/apache/flink-statefun-playground/tree/release-3.3) example, this example demonstrates two "statefun" functions:
 - `shopping/basket` represent users' shopping baskets
 - `shopping/supply` represents a finite supply of products
 
@@ -15,7 +15,7 @@ Build the Flink images defined in the `docker-compose.yaml` file: `docker-compos
 Run the function and the accompanying Flink cluster: `docker-compose up`. _If the Kafka broker appears to crash, run `docker-compose restart kafka-broker` or restart this step._
 
 Now we have our Flink Stateful function running, but we don't have any state. We'll use `harness.py` to create and interact with our `supply` data.
-- Install a few requirements: `pip3 install beautifultable pluralizer`
+- Install a few requirements: `pip3 install beautifultable kafka-python pluralizer`
 - In a new shell, run `python3 harness.py restock` to add to our supply of products.
 - In a new shell, run `python3 harness.py add-to-basket` to take from our supply of products.
 - In a new shell, run `python3 harness.py print-supply` to show a live-feed of changes to our supply of products.

--- a/remote-example/requirements.txt
+++ b/remote-example/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp
-flask==1.1.2
-gunicorn==20.0.4
-apache-flink-statefun==3.2.0
+flask==2.3.3
+gunicorn==21.2.0
+apache-flink-statefun==3.3.0
 pluralizer==1.1.0
 kafka-python==2.0.2
 beautifultable


### PR DESCRIPTION
TODO:
- update Docker image for remote-example when apache/flink-statefun:3.3.0 is available
- update Bootstrap example to Statefun 3.3.0 and Flink 1.16